### PR TITLE
fix url for get_pool_delegators_history

### DIFF
--- a/koios_python/pool.py
+++ b/koios_python/pool.py
@@ -71,7 +71,7 @@ def get_pool_delegators(self, pool_bech32, content_range="0-999"):
 
 
 @Exception_Handler
-def get_pool_delegators_history(self, pool_bech32, epoch_no=None):
+def get_pool_delegators_history(self, pool_bech32, epoch_no=None, content_range="0-999"):
     """
     Return information about active delegators (incl. history) for a given pool and epoch number \
     (all epochs if not specified).
@@ -82,11 +82,12 @@ def get_pool_delegators_history(self, pool_bech32, epoch_no=None):
     :rtype: list.
     """
     timeout = get_timeout()
+    custom_headers = {"Range": str(content_range)}
     if epoch_no is None:
-        info = requests.get(self.POOL_DELEGATORS_HISTORY_URL + pool_bech32, timeout=timeout)
+        info = requests.get(self.POOL_DELEGATORS_HISTORY_URL + pool_bech32, headers=custom_headers, timeout=timeout)
         info = json.loads(info.content)
     else:
-        info = requests.get(f"{self.POOL_DELEGATORS_HISTORY_URL}{pool_bech32}&_epoch={epoch_no}", timeout=timeout)
+        info = requests.get(f"{self.POOL_DELEGATORS_HISTORY_URL}{pool_bech32}&_epoch_no={epoch_no}", headers=custom_headers, timeout=timeout)
         info = json.loads(info.content)
     return info
 

--- a/tests.py
+++ b/tests.py
@@ -30,23 +30,24 @@ import time
 kp = koios_python.URLs() # We need to create an instance of the class URLs
 #print(kp.get_tip())
 
-print('------------------------------------------------------------------------------------------------------------------------------------------------------')
+# print('------------------------------------------------------------------------------------------------------------------------------------------------------')
 
-#print(kp.get_genesis())
+# #print(kp.get_genesis())
 
-print('------------------------------------------------------------------------------------------------------------------------------------------------------')
+# print('------------------------------------------------------------------------------------------------------------------------------------------------------')
 
 #print(kp.get_totals())
+# pprint.pp(kp.get_pool_delegators_history("pool1hrv8gtrm0dgjg6zyss5uwa4nkruzfnh5vrdkr2sayj7x2nw6mjc", 391))
 
-print('------------------------------------------------------------------------------------------------------------------------------------------------------')
+# print('------------------------------------------------------------------------------------------------------------------------------------------------------')
 
-check_big_account = kp.get_account_addresses(["stake1uxqh9rn76n8nynsnyvf4ulndjv0srcc8jtvumut3989cqmgjt49h6"])
-pprint.pp(check_big_account)
+# check_big_account = kp.get_account_addresses(["stake1uxqh9rn76n8nynsnyvf4ulndjv0srcc8jtvumut3989cqmgjt49h6"])
+# pprint.pp(check_big_account)
 
-print('------------------------------------------------------------------------------------------------------------------------------------------------------')
+# print('------------------------------------------------------------------------------------------------------------------------------------------------------')
 
-check_big_account = kp.get_account_addresses(["stake1uxqh9rn76n8nynsnyvf4ulndjv0srcc8jtvumut3989cqmgjt49h6"])
-pprint.pp(check_big_account)
+# check_big_account = kp.get_account_addresses(["stake1uxqh9rn76n8nynsnyvf4ulndjv0srcc8jtvumut3989cqmgjt49h6"])
+# pprint.pp(check_big_account)
 
 
 ############################################################


### PR DESCRIPTION
## Description
Fixed url where we had `_epoch` vs `_epoch_no` and added content range

## Where should the reviewer start?
pools.py -> get_pool_delegators_histroy()

## Motivation and context
The function was not working properly due to a bad URL.

## Which issue it fixes?
None was made

## How has this been tested?
tests.py
